### PR TITLE
Use cursor-based pagination instead of offset pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following REST endpoints are provided:
 |Rhymes|`/rhymes?word=<word>`|
 |Thesaurus|`/thesaurus?word=<word>`|
 |Definitions|`/definitions?word=<word>`|
-|Words of the day|`/wotd?page=<page number>&size=<page size>`|
+|Words of the day|`/wotd?before=<yyyy-MM-dd>&size=<page size>`<br>`before`: inclusive, defaults to today<br>`size`: defaults to 1|
 
 ## How to use it
 Start the application:
@@ -187,60 +187,57 @@ This response example in pretty print:
 ### Words of the day
 
 ```shell
-curl "http://localhost:8080/wotd?page=<page number>&size=<page size>"
+curl "http://localhost:8080/wotd?before=yyyy-MM-dd&size=<page size>"
 ```
 
-For example, to find the words of the day for one week, ending one week ago:
-
+To find to word of the day for today:
 ```shell
-curl "http://localhost:8080/wotd?page=1&size=7"
-{"content":[{"date":"2021-11-20","word":"traitorous"},{"date":"2021-11-19","word":"unplug"},{"date":"2021-11-18","word":"glade"},{"date":"2021-11-17","word":"casework"},{"date":"2021-11-16","word":"replenish"},{"date":"2021-11-15","word":"eiderdown"},{"date":"2021-11-14","word":"oligarchic"}],"pageable":"INSTANCE","size":7,"number":0,"sort":{"empty":true,"sorted":false,"unsorted":true},"numberOfElements":7,"first":true,"last":true,"empty":false}
+curl -i "http://localhost:8080/wotd" 
+```
+
+```json
+[{"date":"2021-11-28","word":"clothesline"}]
+```
+
+To find the word of the day for last week of 2021:
+```shell
+curl -i "http://localhost:8080/wotd?before=2021-12-31&size=7"
+```
+
+```json
+[{"date":"2021-12-31","word":"raindrop"},{"date":"2021-12-30","word":"ceaselessly"},{"date":"2021-12-29","word":"foresail"},{"date":"2021-12-28","word":"haematopoietic"},{"date":"2021-12-27","word":"crosier"},{"date":"2021-12-26","word":"demo"},{"date":"2021-12-25","word":"ceaselessly"}
 ```
 
 This response example in pretty print:
 ```json
-{
-  "content": [
-    {
-      "date": "2021-11-20",
-      "word": "traitorous"
-    },
-    {
-      "date": "2021-11-19",
-      "word": "unplug"
-    },
-    {
-      "date": "2021-11-18",
-      "word": "glade"
-    },
-    {
-      "date": "2021-11-17",
-      "word": "casework"
-    },
-    {
-      "date": "2021-11-16",
-      "word": "replenish"
-    },
-    {
-      "date": "2021-11-15",
-      "word": "eiderdown"
-    },
-    {
-      "date": "2021-11-14",
-      "word": "oligarchic"
-    }
-  ],
-  "pageable": "INSTANCE",
-  "size": 7,
-  "number": 0,
-  "sort": {
-    "empty": true,
-    "sorted": false,
-    "unsorted": true
+[
+  {
+    "date": "2021-12-31",
+    "word": "raindrop"
   },
-  "numberOfElements": 7,
-  "first": true,
-  "last": true,
-  "empty": false
-}
+  {
+    "date": "2021-12-30",
+    "word": "ceaselessly"
+  },
+  {
+    "date": "2021-12-29",
+    "word": "foresail"
+  },
+  {
+    "date": "2021-12-28",
+    "word": "haematopoietic"
+  },
+  {
+    "date": "2021-12-27",
+    "word": "crosier"
+  },
+  {
+    "date": "2021-12-26",
+    "word": "demo"
+  },
+  {
+    "date": "2021-12-25",
+    "word": "ceaselessly"
+  }
+]
 ```

--- a/src/main/kotlin/ca/rmen/poetassistant/restservice/wotd/WotdController.kt
+++ b/src/main/kotlin/ca/rmen/poetassistant/restservice/wotd/WotdController.kt
@@ -20,16 +20,26 @@
 package ca.rmen.poetassistant.restservice.wotd
 
 import ca.rmen.poetassistant.restservice.wotd.model.WotdModel
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
-import org.springframework.data.domain.SliceImpl
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import javax.validation.constraints.Positive
 
 @RestController
+@Validated
 class WotdController(private val service: WotdService) {
 
     @GetMapping("/wotd")
-    fun getWotd(pageable: Pageable): Slice<WotdModel> =
-        SliceImpl(service.findWotdEntries(offset = pageable.offset, size = pageable.pageSize))
+    fun getWotd(
+        @RequestParam("before", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        before: LocalDate?,
+
+        @RequestParam("size", defaultValue = "1")
+        @Positive
+        size: Int
+    ): List<WotdModel> = service.findWotdEntries(before ?: LocalDate.now(), size)
 }

--- a/src/main/kotlin/ca/rmen/poetassistant/restservice/wotd/WotdService.kt
+++ b/src/main/kotlin/ca/rmen/poetassistant/restservice/wotd/WotdService.kt
@@ -41,7 +41,7 @@ class WotdService(private val repository: StemRepository) {
         private const val MAX_INTERESTING_FREQUENCY = 24999
     }
 
-    fun findWotdEntries(offset: Long, size: Int): List<WotdModel> {
+    fun findWotdEntries(before: LocalDate, size: Int): List<WotdModel> {
         // Comment on performance:
         // This will load all the "interesting words" into memory. There are
         // about 20000 entries. In case this could be a performance issue, I
@@ -52,9 +52,8 @@ class WotdService(private val repository: StemRepository) {
         // moving forward, row by row.
         val interestingWords =
             repository.findByGoogleNgramFrequencyBetween(MIN_INTERESTING_FREQUENCY, MAX_INTERESTING_FREQUENCY)
-        val firstDay = LocalDate.now().minusDays(offset)
         return (0 until size).map { resultPosition ->
-            val dateForWotd = firstDay.minusDays(resultPosition.toLong())
+            val dateForWotd = before.minusDays(resultPosition.toLong())
             val positionForDate = Random().apply {
                 setSeed(dateForWotd.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli())
             }.nextInt(interestingWords.size)


### PR DESCRIPTION
Using cursor-based pagination allows us to more easily find the word of a day for a specific date. Or to find the last X words of the day up to a given date.
    
This is an infinite pagination, and there is one word for each date in time. We don't need to provide information in the response about the next or previous ids.
